### PR TITLE
fix: joiner popping reviews before storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ go.work.sum
 
 .ideas/
 .idea/
+.run/
 
 archive/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -131,6 +131,3 @@ services:
       interval: 2s
       timeout: 5s
       retries: 3
-
-# volumes:
-#   rabbitmq_data:  


### PR DESCRIPTION
El joiner creaba el channel al iniciar por mas que todavia no iba a necesitarlo. Al usar el middleware esto habria hecho que popee una review que no iba a joinear