### PR TITLE
Implementación filtro duplicados y guardados a disco

### DIFF
--- a/server/common/duplicateFilter.go
+++ b/server/common/duplicateFilter.go
@@ -5,17 +5,17 @@ import "sort"
 // DuplicateFilter is a filter that accepts unique IDs in a sliding window.
 // It maintains a sorted window of accepted IDs and rejects duplicates.
 // The window is shortened to the position X if all the IDs are consecutive from the start to X.
+//
+// Precondition: IDs must be non-negative integers starting from 0.
+//
 // Example we have window [1,3,5] Meaning that 0,1,3,5 were accepted.
 // If 2 arrives it will be added and the window will become [3,5]. Compacting Because 1,2,3 are consecutive.
 // With this new window we know that ids from 0-3 are already accepted.
-// Note: ids must start from 0
 type DuplicateFilter struct {
-	window []int
+    window []int
 }
 
 // NewDuplicateFilter initializes a new DuplicateFilter with an empty window.
-// The window starts with a sentinel value of -1 to handle the first ID correctly.
-// Ids must begin from 0.
 func NewDuplicateFilter() *DuplicateFilter {
 	return &DuplicateFilter{
 		window: []int{-1},

--- a/server/common/duplicateFilter.go
+++ b/server/common/duplicateFilter.go
@@ -56,21 +56,21 @@ func (f *DuplicateFilter) GetCurrentWindowState() []int {
 	return win
 }
 
-// DuplicateFilterWithShard is a filter that manages multiple shards of DuplicateFilter.
+// DuplicateFilterWithShards is a filter that manages multiple shards of DuplicateFilter.
 // It applies the same logic as DuplicateFilter but allows for separate windows per shard.
-type DuplicateFilterWithShard struct {
+type DuplicateFilterWithShards struct {
 	shards map[int]*DuplicateFilter
 }
 
-func NewDuplicateFilterWithShard() *DuplicateFilterWithShard {
-	return &DuplicateFilterWithShard{
+func NewDuplicateFilterWithShards() *DuplicateFilterWithShards {
+	return &DuplicateFilterWithShards{
 		shards: make(map[int]*DuplicateFilter),
 	}
 }
 
 // ShouldAccept checks if an ID should be accepted in the specified shard.
 // Check ShouldAccept in the DuplicateFilter for the logic of accepting IDs.
-func (f *DuplicateFilterWithShard) ShouldAccept(id int, shardID int) bool {
+func (f *DuplicateFilterWithShards) ShouldAccept(id int, shardID int) bool {
 	if id < 0 {
 		return false // Negative IDs are not accepted
 	}
@@ -84,7 +84,7 @@ func (f *DuplicateFilterWithShard) ShouldAccept(id int, shardID int) bool {
 
 // GetCurrentWindowsState GetCurrentWindowState returns the current state of all shards.
 // It returns a map where keys are shard IDs and values are the current window states of those shards.
-func (f *DuplicateFilterWithShard) GetCurrentWindowsState() map[int][]int {
+func (f *DuplicateFilterWithShards) GetCurrentWindowsState() map[int][]int {
 	winStates := make(map[int][]int)
 	for shardID, filter := range f.shards {
 		winStates[shardID] = filter.GetCurrentWindowState()

--- a/server/common/duplicateFilter.go
+++ b/server/common/duplicateFilter.go
@@ -1,0 +1,93 @@
+package common
+
+import "sort"
+
+// DuplicateFilter is a filter that accepts unique IDs in a sliding window.
+// It maintains a sorted window of accepted IDs and rejects duplicates.
+// The window is shortened to the position X if all the IDs are consecutive from the start to X.
+// Example we have window [1,3,5] Meaning that 0,1,3,5 were accepted.
+// If 2 arrives it will be added and the window will become [3,5]. Compacting Because 1,2,3 are consecutive.
+// With this new window we know that ids from 0-3 are already accepted.
+// Note: ids must start from 0
+type DuplicateFilter struct {
+	window []int
+}
+
+// NewDuplicateFilter initializes a new DuplicateFilter with an empty window.
+// The window starts with a sentinel value of -1 to handle the first ID correctly.
+// Ids must begin from 0.
+func NewDuplicateFilter() *DuplicateFilter {
+	return &DuplicateFilter{
+		window: []int{-1},
+	}
+}
+
+// ShouldAccept returns false for duplicates and bad IDs (negative IDs).
+// returns true when a new ID is accepted and updates the window accordingly.
+func (f *DuplicateFilter) ShouldAccept(id int) bool {
+	if len(f.window) > 0 && id < f.window[0] {
+		return false
+	}
+
+	idx := sort.SearchInts(f.window, id)
+	if idx < len(f.window) && f.window[idx] == id {
+		return false
+	}
+
+	f.window = append(f.window, 0)
+	copy(f.window[idx+1:], f.window[idx:])
+	f.window[idx] = id
+
+	for i := 1; i <= len(f.window); i++ {
+		if i == len(f.window) || f.window[i] != f.window[i-1]+1 {
+			f.window = f.window[i-1:]
+			break
+		}
+	}
+
+	return true
+}
+
+// GetCurrentWindowState returns a copy of the current window state.
+// This is done for saving the state of the filter at any point in time.
+func (f *DuplicateFilter) GetCurrentWindowState() []int {
+	win := make([]int, len(f.window))
+	copy(win, f.window)
+	return win
+}
+
+// DuplicateFilterWithShard is a filter that manages multiple shards of DuplicateFilter.
+// It applies the same logic as DuplicateFilter but allows for separate windows per shard.
+type DuplicateFilterWithShard struct {
+	shards map[int]*DuplicateFilter
+}
+
+func NewDuplicateFilterWithShard() *DuplicateFilterWithShard {
+	return &DuplicateFilterWithShard{
+		shards: make(map[int]*DuplicateFilter),
+	}
+}
+
+// ShouldAccept checks if an ID should be accepted in the specified shard.
+// Check ShouldAccept in the DuplicateFilter for the logic of accepting IDs.
+func (f *DuplicateFilterWithShard) ShouldAccept(id int, shardID int) bool {
+	if id < 0 {
+		return false // Negative IDs are not accepted
+	}
+
+	if _, exists := f.shards[shardID]; !exists {
+		f.shards[shardID] = NewDuplicateFilter()
+	}
+
+	return f.shards[shardID].ShouldAccept(id)
+}
+
+// GetCurrentWindowsState GetCurrentWindowState returns the current state of all shards.
+// It returns a map where keys are shard IDs and values are the current window states of those shards.
+func (f *DuplicateFilterWithShard) GetCurrentWindowsState() map[int][]int {
+	winStates := make(map[int][]int)
+	for shardID, filter := range f.shards {
+		winStates[shardID] = filter.GetCurrentWindowState()
+	}
+	return winStates
+}

--- a/server/common/duplicateFilter_test.go
+++ b/server/common/duplicateFilter_test.go
@@ -162,7 +162,7 @@ func equalSlices(a, b []int) bool {
 }
 
 func TestDuplicateFilterWithShard(t *testing.T) {
-	filter := NewDuplicateFilterWithShard()
+	filter := NewDuplicateFilterWithShards()
 
 	type testCase struct {
 		id          int

--- a/server/common/duplicateFilter_test.go
+++ b/server/common/duplicateFilter_test.go
@@ -1,0 +1,205 @@
+package common
+
+import "testing"
+
+func TestDuplicateFilterHappy(t *testing.T) {
+	filter := NewDuplicateFilter()
+	tests := []struct {
+		id          int
+		expected    bool
+		expectedWin []int // Optional: Expected window state
+	}{
+		{0, true, []int{0}},
+		{1, true, []int{1}},
+		{2, true, []int{2}},
+		{3, true, []int{3}},
+		{4, true, []int{4}},
+		{1, false, []int{4}}, // Duplicate
+		{5, true, []int{5}},
+		{4, false, []int{5}}, // Duplicate
+	}
+	for i, test := range tests {
+		got := filter.ShouldAccept(test.id)
+		if got != test.expected {
+			t.Errorf("[%d] ShouldAccept(%d) = %v; want %v", i, test.id, got, test.expected)
+		}
+
+		if test.expectedWin != nil {
+			window := filter.GetCurrentWindowState()
+			if !equalSlices(window, test.expectedWin) {
+				t.Errorf("[%d] GetCurrentWindowState() = %v; want %v", i, window, test.expectedWin)
+			}
+		}
+	}
+}
+
+func TestDuplicateFilterIncremental(t *testing.T) {
+	filter := NewDuplicateFilter()
+
+	tests := []struct {
+		id          int
+		expected    bool
+		expectedWin []int // Optional: Expected window state
+	}{
+		{0, true, []int{0}},
+		{1, true, []int{1}},
+		{3, true, []int{1, 3}},
+		{2, true, []int{3}}, // Compact: [1,2,3] → [3]
+		{5, true, []int{3, 5}},
+		{4, true, []int{5}}, // Compact: [3,4,5] → [5]
+		{3, false, nil},     // Duplicate
+		{6, true, []int{6}}, // Compact: [5,6] → [6]
+		{8, true, []int{6, 8}},
+		{7, true, []int{8}}, // Compact: [6,7,8] → [8]
+		{9, true, []int{9}}, // Compact: [8,9] → [9]
+		{11, true, []int{9, 11}},
+		{10, true, []int{11}}, // Compact: [9,10,11] → [11]
+		{12, true, []int{12}}, // Compact: [11,12] → [12]
+		{13, true, []int{13}}, // Compact: [12,13] → [13]
+		{13, false, nil},      // Duplicate
+		{14, true, []int{14}}, // Compact: [13,14] → [14]
+		{10, false, nil},      // Duplicate (confirmed)
+		{15, true, []int{15}}, // Compact: [14,15] → [15]
+		{1, false, nil},       // Too old
+	}
+
+	for i, test := range tests {
+		got := filter.ShouldAccept(test.id)
+		if got != test.expected {
+			t.Errorf("[%d] ShouldAccept(%d) = %v; want %v", i, test.id, got, test.expected)
+		}
+
+		if test.expectedWin != nil {
+			window := filter.GetCurrentWindowState()
+			if !equalSlices(window, test.expectedWin) {
+				t.Errorf("[%d] GetCurrentWindowState() = %v; want %v", i, window, test.expectedWin)
+			}
+		}
+	}
+}
+
+func TestDuplicateFilterMoreRange(t *testing.T) {
+	filter := NewDuplicateFilter()
+
+	scenarios := []struct {
+		id          int
+		expected    bool
+		expectedWin []int
+	}{
+		{0, true, []int{0}},
+		{10, true, []int{0, 10}},
+		{1, true, []int{1, 10}},
+		{2, true, []int{2, 10}},   // Compact: [0,1,2,10] → [10]
+		{3, true, []int{3, 10}},   // Compact : [3,10] → [3,10]
+		{4, true, []int{4, 10}},   // Compact: [3,4,10] → [4,10]
+		{10, false, []int{4, 10}}, // Duplicate
+		{5, true, []int{5, 10}},   // Compact: [4,5,10] → [5,10]
+		{11, true, []int{5, 10, 11}},
+		{6, true, []int{6, 10, 11}},  // Compact: [5,6,10,11] → [6,10,11]
+		{4, false, []int{6, 10, 11}}, // Duplicate
+		{7, true, []int{7, 10, 11}},  // Compact: [6,7,10,11] → [7,10,11]
+		{8, true, []int{8, 10, 11}},  // Compact: [7,8,10,11] → [8,10,11]
+		{9, true, []int{11}},         // Compact: [8,9,10,11] → [11]
+		{12, true, []int{12}},        // Compact: [11,12] → [12]
+		{20, true, []int{12, 20}},    // Compact: [12,20] → [20]
+		{15, true, []int{12, 15, 20}},
+		{14, true, []int{12, 14, 15, 20}},
+		{13, true, []int{15, 20}},     // Compact: [12,13,14,15,20] → [15,20]
+		{13, false, []int{15, 20}},    // Duplicate
+		{21, true, []int{15, 20, 21}}, // Compact: [15,20,21] → [20,21]
+	}
+
+	for i, s := range scenarios {
+		got := filter.ShouldAccept(s.id)
+		if got != s.expected {
+			t.Errorf("[%d] ShouldAccept(%d) = %v; want %v",
+				i, s.id, got, s.expected)
+		}
+		if s.expectedWin != nil {
+			win := filter.GetCurrentWindowState()
+			if !equalSlices(win, s.expectedWin) {
+				t.Errorf("[%d] window = %v; want %v",
+					i, win, s.expectedWin)
+			}
+		}
+	}
+}
+
+func TestDuplicateFilterNegative(t *testing.T) {
+	filter := NewDuplicateFilter()
+	tests := []struct {
+		id       int
+		expected bool
+	}{
+		{-1, false}, // Negative ID should be rejected
+		{-10, false},
+		{-100, false},
+		{0, true},    // Zero is valid
+		{1, true},    // Positive IDs should be accepted
+		{-10, false}, // Negative again
+		{0, false},   // Zero again, should be rejected after first acceptance
+	}
+
+	for i, test := range tests {
+		got := filter.ShouldAccept(test.id)
+		if got != test.expected {
+			t.Errorf("[%d] ShouldAccept(%d) = %v; want %v", i, test.id, got, test.expected)
+		}
+	}
+}
+
+// Helper function to compare slices
+func equalSlices(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestDuplicateFilterWithShard(t *testing.T) {
+	filter := NewDuplicateFilterWithShard()
+
+	type testCase struct {
+		id          int
+		shardID     int
+		expected    bool
+		expectedWin []int
+	}
+	// We add 0 1 2 2 5 3 to shard 1
+	// We add 2 0 3 1 2 to shard 2
+	tests := []testCase{
+		{id: 0, shardID: 1, expected: true, expectedWin: []int{0}},
+		{id: 1, shardID: 1, expected: true, expectedWin: []int{1}},
+		{id: 2, shardID: 1, expected: true, expectedWin: []int{2}},
+		{id: 2, shardID: 2, expected: true, expectedWin: []int{-1, 2}},
+		{id: 2, shardID: 1, expected: false, expectedWin: []int{2}},
+		{id: 0, shardID: 2, expected: true, expectedWin: []int{0, 2}},
+		{id: 3, shardID: 2, expected: true, expectedWin: []int{0, 2, 3}},
+		{id: 5, shardID: 1, expected: true, expectedWin: []int{2, 5}},
+		{id: 3, shardID: 1, expected: true, expectedWin: []int{3, 5}},
+		{id: 1, shardID: 2, expected: true, expectedWin: []int{3}},
+		{id: 2, shardID: 2, expected: false, expectedWin: []int{3}}, // duplicate in shard 2
+	}
+
+	for i, test := range tests {
+		got := filter.ShouldAccept(test.id, test.shardID)
+		if got != test.expected {
+			t.Errorf("[%d] ShouldAccept(id=%d, shard=%d) = %v; want %v",
+				i, test.id, test.shardID, got, test.expected)
+		}
+
+		if test.expectedWin != nil {
+			state := filter.GetCurrentWindowsState()
+			gotWin := state[test.shardID]
+			if !equalSlices(gotWin, test.expectedWin) {
+				t.Errorf("[%d] window for shard %d = %v; want %v",
+					i, test.shardID, gotWin, test.expectedWin)
+			}
+		}
+	}
+}

--- a/server/common/safeWrite.go
+++ b/server/common/safeWrite.go
@@ -1,0 +1,130 @@
+package common
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type FailPoint string
+
+const (
+	FailAfterWrite   FailPoint = "after_write"
+	FailAfterSync    FailPoint = "after_sync"
+	FailBeforeRename FailPoint = "before_rename"
+)
+
+// HookFunc lets tests inject failures at named stages.
+// This functions should return an error if the failure should be simulated.
+// Example usage:
+//
+//	hook := func(fp FailPoint) error {
+//	    if fp == FailAfterWrite {
+//	        return errors.New("simulated failure after write")
+//	    }
+//
+// You can also simulate death by doing os.Exit(1) or panic().
+// In production, you’ll pass `nil` to disable.
+type HookFunc func(FailPoint) error
+
+// AtomicWriteFile writes data to a temporary file and then renames it to the target filename.
+// This ensures that the file is only replaced if the write is successful.
+// It uses os.CreateTemp to create a temporary file in the same directory as the target file.
+// Then it syncs the temporary file to ensure all data is written to disk.
+// Finally, it renames the temporary file to the target filename.
+// a test-only "hook" can be injected to simulate failures at various points in the process.
+func AtomicWriteFile(filename string, data []byte, hook HookFunc) error {
+	dir, base := filepath.Dir(filename), filepath.Base(filename)
+
+	tmp, err := os.CreateTemp(dir, base+".tmp")
+	if err != nil {
+		return err
+	}
+	// always clean up on error
+	defer tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	// 1) write
+	if _, err := io.Copy(tmp, bytes.NewReader(data)); err != nil {
+		return err
+	}
+	if err := callHook(hook, FailAfterWrite); err != nil {
+		return err
+	}
+
+	// 2) fsync
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := callHook(hook, FailAfterSync); err != nil {
+		return err
+	}
+
+	// 3) close
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	// 4) before rename
+	if err := callHook(hook, FailBeforeRename); err != nil {
+		return err
+	}
+
+	// 5) rename
+	return os.Rename(tmp.Name(), filename)
+}
+
+// callHook executes the provided hook function with the given fail point.
+// If the hook is nil, it does nothing and returns nil.
+func callHook(h HookFunc, point FailPoint) error {
+	if h == nil {
+		return nil
+	}
+	return h(point)
+}
+
+// CleanupOldTemps deletes .tmp files that are older than the olderThan parameter.
+func CleanupOldTemps(dir, base string, olderThan time.Duration) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	cutoff := time.Now().Add(-olderThan)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), base) && strings.HasSuffix(e.Name(), ".tmp") {
+			info, _ := e.Info()
+			if info.ModTime().Before(cutoff) {
+				err := os.Remove(filepath.Join(dir, e.Name()))
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// AppendLine appends a record to a file in a safe manner.
+// It opens the file for appending, writes the data, and ensures that the file is synced to disk.
+// If the file does not exist, it will be created.
+func AppendLine(filename string, data []byte) error {
+	// open file for append
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Write the record to the file
+	if _, err := io.Copy(f, bytes.NewReader(data)); err != nil {
+		return err
+	}
+	// sync file data
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/common/safeWrite.go
+++ b/server/common/safeWrite.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -43,13 +44,17 @@ func AtomicWriteFile(filename string, data []byte, hook HookFunc) error {
 	if err != nil {
 		return err
 	}
-	// always clean up on error
-	defer tmp.Close()
-	defer os.Remove(tmp.Name())
+	var success bool
+	defer func() {
+		if !success {
+			tmp.Close() // We close the temp file if we fail to rename it.
+		}
+		os.Remove(tmp.Name())
+	}()
 
 	// 1) write
 	if _, err := io.Copy(tmp, bytes.NewReader(data)); err != nil {
-		return err
+		return fmt.Errorf("failed to write data to temporary file %s: %w", tmp.Name(), err)
 	}
 	if err := callHook(hook, FailAfterWrite); err != nil {
 		return err
@@ -57,7 +62,7 @@ func AtomicWriteFile(filename string, data []byte, hook HookFunc) error {
 
 	// 2) fsync
 	if err := tmp.Sync(); err != nil {
-		return err
+		return fmt.Errorf("failed to sync temporary file %s: %w", tmp.Name(), err)
 	}
 	if err := callHook(hook, FailAfterSync); err != nil {
 		return err
@@ -74,7 +79,12 @@ func AtomicWriteFile(filename string, data []byte, hook HookFunc) error {
 	}
 
 	// 5) rename
-	return os.Rename(tmp.Name(), filename)
+	err = os.Rename(tmp.Name(), filename)
+	if err != nil {
+		return fmt.Errorf("failed to rename temporary file %s to %s: %w", tmp.Name(), filename, err)
+	}
+	success = true
+	return nil
 }
 
 // callHook executes the provided hook function with the given fail point.
@@ -90,16 +100,19 @@ func callHook(h HookFunc, point FailPoint) error {
 func CleanupOldTemps(dir, base string, olderThan time.Duration) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read directory %s: %w", dir, err)
 	}
 	cutoff := time.Now().Add(-olderThan)
 	for _, e := range entries {
 		if strings.HasPrefix(e.Name(), base) && strings.HasSuffix(e.Name(), ".tmp") {
-			info, _ := e.Info()
+			info, err := e.Info()
+			if err != nil {
+				return fmt.Errorf("failed to get info for file %s: %w", e.Name(), err)
+			}
 			if info.ModTime().Before(cutoff) {
 				err := os.Remove(filepath.Join(dir, e.Name()))
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to remove old temporary file %s: %w", e.Name(), err)
 				}
 			}
 		}
@@ -114,17 +127,17 @@ func AppendLine(filename string, data []byte) error {
 	// open file for append
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open file %s for appending: %w", filename, err)
 	}
 	defer f.Close()
 
 	// Write the record to the file
 	if _, err := io.Copy(f, bytes.NewReader(data)); err != nil {
-		return err
+		return fmt.Errorf("failed to write data to file %s: %w", filename, err)
 	}
 	// sync file data
 	if err := f.Sync(); err != nil {
-		return err
+		return fmt.Errorf("failed to sync file %s: %w", filename, err)
 	}
 	return nil
 }

--- a/server/common/safeWrite_test.go
+++ b/server/common/safeWrite_test.go
@@ -1,0 +1,277 @@
+// atomic/atomic_test.go
+package common_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+	"tp-sistemas-distribuidos/server/common"
+)
+
+// AtomicWriteFile tests ---------------------------------------
+// All the points at which we allow failure injection:
+var allFailPoints = []common.FailPoint{
+	common.FailAfterWrite,
+	common.FailAfterSync,
+	common.FailBeforeRename,
+}
+
+// 1) Happy path, small file
+func TestAtomicWriteFile_Success_Small(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "foo.txt")
+	data := []byte("hello")
+
+	if err := common.AtomicWriteFile(target, data, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("content = %q; want %q", got, "hello")
+	}
+}
+
+// 2) Happy path, "big" file (~100MB)
+func TestAtomicWriteFile_Success_Big(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "big.bin")
+
+	data := make([]byte, 100<<20) // 100 MiB of data
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	if err := common.AtomicWriteFile(target, data, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if len(got) != len(data) {
+		t.Errorf("size = %d; want %d", len(got), len(data))
+	}
+	// optional: spot-check first/last bytes
+	if got[0] != data[0] || got[len(got)-1] != data[len(data)-1] {
+		t.Error("data mismatch at boundaries")
+	}
+}
+
+//  3. No-original case: for each fail‐point, ensure we get an error
+//     and that the target file does NOT exist afterward.
+func TestAtomicWriteFile_FailHooks_NoOriginal(t *testing.T) {
+	for _, fp := range allFailPoints {
+		t.Run(string(fp), func(t *testing.T) {
+			dir := t.TempDir()
+			target := filepath.Join(dir, "nofile.txt")
+
+			// hook that only fails at fp
+			hook := func(p common.FailPoint) error {
+				if p == fp {
+					return errors.New("injected " + string(p))
+				}
+				return nil
+			}
+
+			err := common.AtomicWriteFile(target, []byte("data"), hook)
+			if err == nil || err.Error() != "injected "+string(fp) {
+				t.Fatalf("for %s: expected injected error, got %v", fp, err)
+			}
+
+			if _, statErr := os.Stat(target); !os.IsNotExist(statErr) {
+				t.Errorf("for %s: target should not exist, stat error = %v", fp, statErr)
+			}
+		})
+	}
+}
+
+//  4. Keep‐original case: we start with an existing file,
+//     then for each fail‐point, ensure the original stays intact.
+func TestAtomicWriteFile_FailHooks_KeepOriginal(t *testing.T) {
+	origContent := []byte("ORIGINAL")
+	for _, fp := range allFailPoints {
+		t.Run(string(fp), func(t *testing.T) {
+			dir := t.TempDir()
+			target := filepath.Join(dir, "keep.txt")
+
+			// write the original file
+			if err := common.AtomicWriteFile(target, origContent, nil); err != nil {
+				t.Fatalf("setup (%s): could not write original: %v", fp, err)
+			}
+
+			// hook that only fails at fp
+			hook := func(p common.FailPoint) error {
+				if p == fp {
+					return errors.New("injected " + string(p))
+				}
+				return nil
+			}
+
+			err := common.AtomicWriteFile(target, []byte("NEW"), hook)
+			if err == nil || err.Error() != "injected "+string(fp) {
+				t.Fatalf("for %s: expected injected error, got %v", fp, err)
+			}
+
+			// verify original still there
+			got, readErr := os.ReadFile(target)
+			if readErr != nil {
+				t.Fatalf("for %s: could not read back original: %v", fp, readErr)
+			}
+			if string(got) != string(origContent) {
+				t.Errorf("for %s: content = %q; want %q", fp, got, origContent)
+			}
+
+			// ensure no temp files remain
+			dirEntries, _ := os.ReadDir(dir)
+			for _, e := range dirEntries {
+				if filepath.Ext(e.Name()) == ".tmp" {
+					t.Errorf("for %s: leftover temp file: %s", fp, e.Name())
+				}
+			}
+		})
+	}
+}
+
+// CleanupOldTems --------------------------------------------
+// helper to touch a file and set its mod-time to now-delta
+func touchWithAge(t *testing.T, dir, name string, age time.Duration) {
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+		t.Fatalf("failed to create %s: %v", name, err)
+	}
+	// set its mod time to now minus age
+	past := time.Now().Add(-age)
+	if err := os.Chtimes(path, past, past); err != nil {
+		t.Fatalf("failed to chtimes %s: %v", name, err)
+	}
+}
+
+func TestCleanupOldTemps_RemovesOnlyOldMatching(t *testing.T) {
+	dir := t.TempDir()
+	base := "config"
+
+	// create various files:
+	touchWithAge(t, dir, base+".1.tmp", 2*time.Hour)    // should be removed
+	touchWithAge(t, dir, base+".2.tmp", 30*time.Minute) // should stay
+	touchWithAge(t, dir, "other.1.tmp", 2*time.Hour)    // wrong prefix
+	touchWithAge(t, dir, base+".3.txt", 2*time.Hour)    // wrong suffix
+
+	// run cleanup: remove anything older than 1h matching base*.tmp
+	if err := common.CleanupOldTemps(dir, base, 1*time.Hour); err != nil {
+		t.Fatalf("CleanupOldTemps failed: %v", err)
+	}
+
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+	exists := map[string]bool{}
+	for _, e := range ents {
+		exists[e.Name()] = true
+	}
+
+	// assert expectations
+	if exists[base+".1.tmp"] {
+		t.Error("expected config.1.tmp to be removed")
+	}
+	if !exists[base+".2.tmp"] {
+		t.Error("expected config.2.tmp to remain")
+	}
+	if !exists["other.1.tmp"] {
+		t.Error("expected other.1.tmp to remain (wrong prefix)")
+	}
+	if !exists[base+".3.txt"] {
+		t.Error("expected config.3.txt to remain (wrong suffix)")
+	}
+}
+
+func TestCleanupOldTemps_NothingToRemove(t *testing.T) {
+	dir := t.TempDir()
+	base := "foo"
+
+	// create only fresh matching files
+	touchWithAge(t, dir, base+".a.tmp", 10*time.Minute)
+	touchWithAge(t, dir, base+".b.tmp", 5*time.Minute)
+
+	if err := common.CleanupOldTemps(dir, base, 1*time.Hour); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ents, _ := os.ReadDir(dir)
+	if len(ents) != 2 {
+		t.Errorf("expected 2 files left, got %d", len(ents))
+	}
+}
+
+func TestCleanupOldTemps_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	// no files at all
+	if err := common.CleanupOldTemps(dir, "anything", time.Minute); err != nil {
+		t.Fatalf("cleanup on empty dir should not error, got %v", err)
+	}
+}
+
+// AppendLine tests ---------------------------------------
+// TestAppendLine_Success ensures that AppendLine appends data correctly.
+func TestAppendLine_Success(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "file.txt")
+
+	// First append
+	err := common.AppendLine(target, []byte("first\n"))
+	if err != nil {
+		t.Fatalf("unexpected error on first append: %v", err)
+	}
+
+	// Second append
+	err = common.AppendLine(target, []byte("second\n"))
+	if err != nil {
+		t.Fatalf("unexpected error on second append: %v", err)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	expect := "first\nsecond\n"
+	if string(data) != expect {
+		t.Errorf("content = %q, want %q", string(data), expect)
+	}
+}
+
+// TestAppendLine_LargeWrite writes several MBs to exceed PIPE_BUF and ensures no partial writes
+func TestAppendLine_LargeWrite(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "big.txt")
+
+	// generate ~10MiB of data
+	chunk := bytes.Repeat([]byte("A"), 1024*1024) // 1 MiB chunk
+	var buf bytes.Buffer
+	for i := 0; i < 10; i++ {
+		buf.Write(chunk)
+	}
+	data := buf.Bytes()
+
+	err := common.AppendLine(target, data)
+	if err != nil {
+		t.Fatalf("unexpected error on large write: %v", err)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat failed: %v", err)
+	}
+
+	if info.Size() != int64(len(data)) {
+		t.Errorf("size = %d, want %d", info.Size(), len(data))
+	}
+}


### PR DESCRIPTION
- Se agrego  safeWrite.go en donde se encuentran las funciones importantes  de `AtomicWriteFile`  y `AppendLine` para la escritura de la snapshot y log correspondientemente. 
- También se añadio el archivo duplicateFilter.go con los structs `DuplicateFilter` y `DuplicateFilterWithShards` para el filtrado de duplicados en nodos con shards y sin shards. 